### PR TITLE
extract cookie as well as token for slack auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ To aid in this, the extension gives helpful shortcuts to grab a slack user token
 
 The extension also allows you to search for and insert emoji using the chrome `omnibar`. Just type `cmd+l` to focus on the bar, then `:, tab` and you'll be able to search existing emoji. When you find what you're looking for, press enter to copy it to your clipboard and enter it under your cursor. You can paste them in either as the direct url, a markdown link to the url, a markdown image (works great on github PRs), or html image.
 
+### Oh my god you're stealing my cookies
+
+Well, _you're_ stealing your cookies. It's a serious and legitimate security risk, and using this extension probably makes your slack interactions less secure. I comfort myself with the fact that Slack operated without cookie based authentication for 8 years (until roughly July 2021), so for the 3 years or so that emojme and that somewhat lacking auth scheme were coexisting, you were equally if not more unsafe.
+
 ## Installation
 
 At time of writing, the slack emoji anywhere extension is only available unpacked, not through the chrome web store. There are [all kinds](https://stackoverflow.com/a/24577660/5261045) of [guides](https://developer.chrome.com/extensions/getstarted#manifest) to get that done, but the short version is to download or clone this repository, open `chrome://extensions`, turn on `Developer Mode`, and click `Load Unpacked` in the upper right. Have fun! :goatbutt:

--- a/manifest.json
+++ b/manifest.json
@@ -15,7 +15,16 @@
     "persistent": false
   },
   "content_security_policy": "script-src 'self'; object-src 'self'; img-src 'self' data: https://emoji.slack-edge.com",
-  "permissions": ["storage", "activeTab", "tabs", "http://*/", "https://*/", "clipboardWrite", "clipboardRead"],
+  "permissions": [
+    "storage",
+    "activeTab",
+    "tabs",
+    "http://*/",
+    "https://*/",
+    "clipboardWrite",
+    "clipboardRead",
+    "cookies"
+  ],
   "icons": {
     "16": "images/icon_16.png",
     "32": "images/icon_32.png",

--- a/popup.html
+++ b/popup.html
@@ -52,7 +52,7 @@
         <td><button id="openCustomizePage">Add More Emoji</button></td>
       </tr>
       <tr>
-        <td><button id="getSlackToken">Get Slack Token</button></td>
+        <td><button id="getSlackAuth">Get Slack Token and Cookie</button></td>
       </tr>
       <tr>
         <td><button id="getSlackEmoji">Refresh Emoji</button></td>

--- a/popup.js
+++ b/popup.js
@@ -17,8 +17,8 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   });
 
-  document.getElementById("getSlackToken").addEventListener('click', () => {
-    getSlackToken();
+  document.getElementById("getSlackAuth").addEventListener('click', () => {
+    getSlackAuth();
   });
 
   document.getElementById("getSlackEmoji").addEventListener('click', () => {
@@ -82,12 +82,12 @@ function requestAlert(alertText) {
   );
 }
 
-function getSlackToken() {
-  chrome.runtime.sendMessage({message: 'getSlackToken', callback: 'alert'});
+function getSlackAuth() {
+  chrome.runtime.sendMessage({message: 'getSlackAuth', callback: 'alert'});
 }
 
 function getSlackEmoji() {
-  chrome.runtime.sendMessage({message: 'getSlackToken', callback: 'getSlackEmoji'});
+  chrome.runtime.sendMessage({message: 'getSlackAuth', callback: 'getSlackEmoji'});
 }
 
 


### PR DESCRIPTION
## Why 

Welp, Slack is cracking down. The days of using tokens for whatever the heck you want are over, now we need cookies too. I used to love cookies, ya know? 

Anyway, as part of the response to https://github.com/jackellenberger/emojme/issues/60, we need an easy way to extract both a slack token and its cooperative cookie, which is ~wisely~ unfortunately, HttpOnly. This means we can't just grab it in javascript, you need a them on the inside... a them like... google chrome. So here this extension is, requesting more permissions to do more seemingly nefarious but really quite silly things. 

## What

The actual change here (in addition to adding `cookies` permissions, is to update the `Get Slack Token` button to be a `Get Slack Token and Cookie` button. Clicking it will return (and copy to your clipboard) a jsonblob containing the slack subdomain, token, and cookie.

## What's next

Update emojme to accept these auth blobs so emoji shenanigans remains a bada bing bada boom type operation, nice and easy. :promoves:

